### PR TITLE
Missing parameter in recursive process_conf call

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -176,7 +176,7 @@ def process_conf(resource_obj, command, conf_name, run = false)
   case resource_obj
   when Array
     resource_obj.each_with_index do |obj, i|
-      process_conf(obj, command, "#{conf_name}_#{i + 1}")
+      process_conf(obj, command, "#{conf_name}_#{i + 1}", run)
     end
   when Hash
     write_conf(conf_path, resource_obj)


### PR DESCRIPTION
Corrected missing parameter 'run' to recursive process_conf call when dealing with Array resource_obj type.

Without this, exec_flyway will never be called when processing either Hash or String types with alt_conf configured.